### PR TITLE
Create a Lightness Renderer

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -9,7 +9,7 @@ dotenv.config();
 const app = express();
 const port = process.env.PORT;
 
-app.use(express.json());
+app.use(express.json({ limit: 1024 ** 3 }));
 
 app.use("/canvas", canvas);
 

--- a/src/canvas/text/quick-start.ts
+++ b/src/canvas/text/quick-start.ts
@@ -1,12 +1,15 @@
 import { Router } from "express";
 import { DrawOptions, convertToPixelMap } from "./renderers/pixelMap";
-import { PrintOptions, transformAverage } from "./transformers/average";
+import {
+	TransformAverageOptions,
+	transformAverage,
+} from "./transformers/average";
 import { typeMap } from "../../helpers/type-map";
 
 const router = Router();
 
 router.get("/pma", (_, res) => {
-	const exampleBody: DrawOptions & PrintOptions = {
+	const exampleBody: DrawOptions & TransformAverageOptions = {
 		text: "demo",
 		fontFamily: "Arial",
 		fontSize: 20,

--- a/src/canvas/text/quick-start.ts
+++ b/src/canvas/text/quick-start.ts
@@ -5,6 +5,11 @@ import {
 	transformAverage,
 } from "./transformers/average";
 import { typeMap } from "../../helpers/type-map";
+import {
+	TransformLightnessOptions,
+	getLightness,
+	transformLightness,
+} from "./transformers/lightness";
 
 const router = Router();
 
@@ -45,6 +50,46 @@ router.post("/pma/:text?", (req, res) => {
 
 	res.statusCode = 200;
 	res.send(transformedAverage);
+});
+
+type PmlRequest = DrawOptions &
+	TransformLightnessOptions & {
+		symbols?: string[];
+		symbolRenderOptions: Omit<DrawOptions, "text">;
+		symbolLightnessOptions: TransformLightnessOptions;
+	};
+
+router.post("/pml/:text?", (req, res) => {
+	// form this request as PmlRequest
+	const body: PmlRequest = req.body;
+
+	// need to create the map first
+	const symbols: string[] =
+		body.symbols ||
+		new Array(256 - 32).fill("").map((w, i) => String.fromCharCode(i + 31));
+	const symbolMap = symbols.map((symbol) => {
+		const renderedSymbol = convertToPixelMap({
+			...body.symbolRenderOptions,
+			text: symbol,
+		});
+
+		return getLightness(
+			symbol,
+			renderedSymbol,
+			body.symbolLightnessOptions
+		);
+	});
+
+	// need to render the actual text
+	const pixelMap = convertToPixelMap({
+		...body,
+		text: req.params.text || req.body.text,
+	});
+
+	const transformedLightness = transformLightness(pixelMap, symbolMap, body);
+
+	res.statusCode = 200;
+	res.send(transformedLightness);
 });
 
 export default router;

--- a/src/canvas/text/renderers/index.ts
+++ b/src/canvas/text/renderers/index.ts
@@ -6,13 +6,15 @@ const router = Router();
 
 router.get("/pixelMap", (_, res) => {
 	const exampleBody: DrawOptions = {
-		text: "demo",
-		fontFamily: "demo",
-		fontSize: 10,
+		text: ".",
+		fontFamily: "Arial",
+		fontSize: 20,
 		fill: true,
+		forceWidth: 15,
+		forceHeight: 10,
 	};
 	const mappedType = typeMap({
-		params: { text: "demo" },
+		params: { text: "." },
 		body: exampleBody,
 	});
 

--- a/src/canvas/text/renderers/pixelMap.ts
+++ b/src/canvas/text/renderers/pixelMap.ts
@@ -6,6 +6,8 @@ export type DrawOptions = {
 	fontSize: number;
 	fontFamily: string;
 	fill?: boolean;
+	forceWidth?: number;
+	forceHeight?: number;
 };
 
 export type Rgb = {
@@ -19,11 +21,16 @@ export function convertToPixelMap({
 	fontSize,
 	fontFamily,
 	fill,
+	forceWidth,
+	forceHeight,
 }: DrawOptions): Rgb[][] {
 	const canvas: HTMLCanvasElement = doc.createElement("canvas");
 	const context = canvas.getContext("2d")!;
 
-	const [width, height] = measureString(text, `${fontSize}px '${fontFamily}`);
+	let [width, height] = measureString(text, `${fontSize}px '${fontFamily}`);
+	if (forceWidth) width = forceWidth;
+	if (forceHeight) height = forceHeight;
+
 	if (!width || !height) return [];
 
 	/**

--- a/src/canvas/text/transformers/average.ts
+++ b/src/canvas/text/transformers/average.ts
@@ -1,7 +1,7 @@
 import { trim } from "../helpers/trim";
 import { Rgb } from "../renderers/pixelMap";
 
-export type PrintOptions = {
+export type TransformAverageOptions = {
 	background: string;
 	foreground: string;
 	threshold: number;
@@ -12,7 +12,10 @@ export type PrintOptions = {
  * by new lines, represented using a binary foreground/background controlled
  * by a threshold.
  */
-export function transformAverage(body: Rgb[][], options: PrintOptions) {
+export function transformAverage(
+	body: Rgb[][],
+	options: TransformAverageOptions
+) {
 	let result = "";
 
 	let transform = body.map((row) =>

--- a/src/canvas/text/transformers/index.ts
+++ b/src/canvas/text/transformers/index.ts
@@ -1,7 +1,13 @@
 import { Router } from "express";
-import { PrintOptions, transformAverage } from "./average";
+import { TransformAverageOptions, transformAverage } from "./average";
 import { typeMap } from "../../../helpers/type-map";
 import { Rgb } from "../renderers/pixelMap";
+import {
+	CharacterSample,
+	TransformLightnessOptions,
+	getLightness,
+	transformLightness,
+} from "./lightness";
 
 const router = Router();
 
@@ -11,7 +17,7 @@ router.get("/average", (_, res) => {
 		g: 0,
 		b: 0,
 	};
-	const exampleBody: PrintOptions = {
+	const exampleBody: TransformAverageOptions = {
 		background: "demo",
 		foreground: "demo",
 		threshold: 200,
@@ -35,6 +41,74 @@ router.post("/average", (req, res) => {
 
 	res.statusCode = 200;
 	res.send(average);
+});
+
+router.get("/lightness", (req, res) => {
+	const examplePixelData: Rgb = {
+		r: 0,
+		g: 0,
+		b: 0,
+	};
+	const exampleSample: CharacterSample = {
+		text: ".",
+		lightness: 0,
+	};
+	const exampleOptions: TransformLightnessOptions = {
+		cutoffLightness: 0,
+	};
+
+	const mappedType = typeMap({
+		body: {
+			data: [[examplePixelData]],
+			samples: [exampleSample],
+			...exampleOptions,
+		},
+	});
+
+	const content = JSON.stringify(mappedType);
+
+	res.statusCode = 200;
+	res.contentType("application/json");
+	res.send(content);
+});
+router.post("/lightness", (req, res) => {
+	const light = transformLightness(req.body.data, req.body.samples, req.body);
+	console.log(req.body);
+
+	res.statusCode = 200;
+	res.send(light);
+});
+
+router.get("/mapLightness", (req, res) => {
+	const examplePixelData: Rgb = {
+		r: 0,
+		g: 0,
+		b: 0,
+	};
+	const exampleBody: {
+		text: string;
+		data: Rgb[][];
+	} & TransformLightnessOptions = {
+		text: ".",
+		data: [[examplePixelData]],
+		cutoffLightness: 0,
+	};
+
+	const mappedType = typeMap({
+		body: exampleBody,
+	});
+
+	const content = JSON.stringify(mappedType);
+
+	res.statusCode = 200;
+	res.contentType("application/json");
+	res.send(content);
+});
+router.post("/mapLightness", (req, res) => {
+	const lightness = getLightness(req.body.text, req.body.data, req.body);
+
+	res.statusCode = 200;
+	res.send(lightness);
 });
 
 export default router;

--- a/src/canvas/text/transformers/lightness.ts
+++ b/src/canvas/text/transformers/lightness.ts
@@ -1,0 +1,98 @@
+import { trim } from "../helpers/trim";
+import { Rgb } from "../renderers/pixelMap";
+
+export type CharacterSample = {
+	text: string;
+	lightness: number;
+};
+
+export type TransformLightnessOptions = {
+	cutoffLightness?: number; // any lightness greater than this will be trimmed
+};
+
+function lightness(color: Rgb) {
+	// Least + Most Colored are contrived interpretations of the
+	// min/max of the RGB colour channels, but denote essentially
+	// the strength of the colour with respect to the remainder of
+	// the colour.
+	const leastColored = Math.min(color.r, color.g, color.b);
+	const mostColored = Math.max(color.r, color.g, color.b);
+
+	// Aproximate a greyscale representation of the colour
+	const mean = (leastColored + mostColored) / 2;
+
+	// Scale it between 0 and 1.
+	const scaled = mean / 255;
+
+	return scaled;
+}
+
+export function getLightness(
+	text: string,
+	body: Rgb[][],
+	options: TransformLightnessOptions
+): CharacterSample {
+	let transform = body.map((row) => row.map((pixel) => lightness(pixel)));
+	transform = trim(
+		transform,
+		(lightness) =>
+			options.cutoffLightness !== undefined &&
+			lightness >= options.cutoffLightness
+	);
+
+	let sum = transform.reduce((sum, currentRow) => {
+		return (
+			sum +
+			currentRow.reduce(
+				(innerSum, currentPixel) => innerSum + currentPixel,
+				0
+			)
+		);
+	}, 0);
+
+	const height = transform.length;
+	const width = height > 0 ? transform[0].length : 0;
+
+	return {
+		text,
+		lightness: sum / (width * height),
+	};
+}
+
+export function transformLightness(
+	body: Rgb[][],
+	samples: CharacterSample[],
+	options: TransformLightnessOptions
+) {
+	if (samples.length === 0) return "";
+	let result = "";
+
+	let transform = body.map((row) => row.map((pixel) => lightness(pixel)));
+
+	transform = trim(
+		transform,
+		(lightness) =>
+			options.cutoffLightness !== undefined &&
+			lightness >= options.cutoffLightness
+	);
+
+	transform.forEach((row) => {
+		row.forEach((lightness) => {
+			// want to fetch
+			const distanceMap: CharacterSample[] = samples.map((sample) => ({
+				text: sample.text,
+				lightness: Math.abs(sample.lightness - lightness),
+			}));
+
+			const min = distanceMap.reduce((min, cur) => {
+				return cur.lightness < min.lightness ? cur : min;
+			}, distanceMap[0]);
+
+			result = result.concat(min.text);
+		});
+
+		result = result.concat("\n");
+	});
+
+	return result;
+}

--- a/src/canvas/text/transformers/lightness.ts
+++ b/src/canvas/text/transformers/lightness.ts
@@ -65,6 +65,7 @@ export function transformLightness(
 	options: TransformLightnessOptions
 ) {
 	if (samples.length === 0) return "";
+
 	let result = "";
 
 	let transform = body.map((row) => row.map((pixel) => lightness(pixel)));


### PR DESCRIPTION
This is more or less a generalisation to the average renderer, and permits the use of more symbols.

A 2 symbol lightness render is effectively an average render (can invert if using the renderer directly; the quickstart endpoint doesn't permit inversion)

Example request to the quickstart endpoint:
```
curl --location 'http://localhost:8000/canvas/text/pml/' \
--header 'Content-Type: application/json' \
--data '{
    "text": "Ally",
    "fontFamily": "Arial",
    "fontSize": 20,
    "fill": true,
    "symbols": [" ", ".", "x", "X"],
    "cutoffLightness": 0.9,
    "symbolRenderOptions": {
        "fontFamily": "Arial",
        "fontSize": 40,
        "fill": true,
        "forceWidth": 30,
        "forceHeight": 20
    },
    "symbolLightnessOptions": {}
}'
```